### PR TITLE
Fix ajax field nonce for ACF Pro >=  6.3.2 

### DIFF
--- a/acf-field-network-post-select.php
+++ b/acf-field-network-post-select.php
@@ -3,7 +3,7 @@
 Plugin Name: Advanced Custom Fields: Network posts select field
 Plugin URI: https://github.com/timiwahalahti/acf-field-post-object-network/
 Description: Adds a ACF field that allows selecting posts across the network sites.
-Version: 1.2.0
+Version: 1.2.1
 Author: Timi Wahalahti
 Author URI: https://sipp.is
 License: GPLv3 or later

--- a/class-sippis-acf-field-network-post-select.php
+++ b/class-sippis-acf-field-network-post-select.php
@@ -25,7 +25,11 @@ class sippis_acf_field_network_post_select extends acf_field {
   } // end __construct
 
   function ajax_query() {
-    if ( ! acf_verify_ajax() ) {
+    
+    $nonce = acf_request_arg( 'nonce', '' );
+		$key   = acf_request_arg( 'field_key', '' );
+    
+    if ( ! acf_verify_ajax( $nonce, $key ) ) {
       die();
     }
 
@@ -339,6 +343,7 @@ class sippis_acf_field_network_post_select extends acf_field {
     // $field['multiple']  = false;
     $field['ui']        = true;
     $field['ajax']      = true;
+    $field['nonce']     = wp_create_nonce( $field['key'] );
     $field['choices']   = [];
 
     // try to get posts based on field value

--- a/class-sippis-acf-field-network-post-select.php
+++ b/class-sippis-acf-field-network-post-select.php
@@ -358,8 +358,8 @@ class sippis_acf_field_network_post_select extends acf_field {
       }
     }
 
-    // change field value format so it's in same format with AJAX query return
-    $field['value'] = $field['value']['site_id'] . '|' . $field['value']['post_id'];
+    // change field value format so it's in same format with AJAX query return.
+    $field['value'] = isset($field['value'], $field['value']['site_id'], $field['value']['post_id']) ? $field['value']['site_id'] . '|' . $field['value']['post_id'] : '';
 
     acf_render_field( $field );
   } // end render_field


### PR DESCRIPTION
ACF 6.3.2 broke this plugin because of a change in how the nonce is verified. 
Please merge my fix :)

I've also included a little check for the existence of the requested array offsets, as this was another issue i've come across before.

Kind Regards
Jann

